### PR TITLE
Pin container versions and add timeout for ffmpeg

### DIFF
--- a/docker/bambu-liveview/common-liveview.yml
+++ b/docker/bambu-liveview/common-liveview.yml
@@ -5,10 +5,10 @@ services:
         image: linuxserver/ffmpeg
         restart: always
         environment:
-            PRINTER_HOST: FIXME
+            PRINTER_HOST: DONT_TOUCH
             PRINTER_USER: bblp
-            PRINTER_ID: FIXME
-            PRINTER_ACCESS_CODE: FIXME
+            PRINTER_ID: DONT_TOUCH
+            PRINTER_ACCESS_CODE: DONT_TOUCH
             PRINTER_PORT: 322
             PRINTER_URL: /streaming/live/1
             RTSP_SERVER: mediamtx:8554
@@ -17,6 +17,7 @@ services:
             - "-c"
             - >
               /usr/local/bin/ffmpeg
+              -timeout 30000000
               -re -stream_loop -1
               -i rtsps://$${PRINTER_USER}:$${PRINTER_ACCESS_CODE}@$${PRINTER_HOST}:$${PRINTER_PORT}$${PRINTER_URL}
               -c:v copy -f rtsp -rtsp_transport tcp

--- a/docker/bambu-liveview/example - compose.yml
+++ b/docker/bambu-liveview/example - compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     mediamtx:
-        image: bluenviron/mediamtx
+        image: bluenviron/mediamtx:1.8.2
         restart: always
         volumes:
             - ./mediamtx.yml:/mediamtx.yml
@@ -27,7 +27,7 @@ services:
         entrypoint: /usr/bin/java -Djdk.tls.useExtendedMasterSecret=false -jar bambu-web-runner.jar
 
     nginx:
-        image: nginx:stable-alpine
+        image: nginx:1.26-alpine
         restart: always
         volumes:
             - ./reverse-proxy.conf:/etc/nginx/conf.d/default.conf

--- a/docker/bambu-liveview/reverse-proxy.conf
+++ b/docker/bambu-liveview/reverse-proxy.conf
@@ -24,7 +24,9 @@ server {
 
     location /_camerastream/ {
         rewrite /_camerastream/(.*) /$1  break;
-        proxy_pass http://mediamtx;
+        proxy_redirect / /_camerastream/;
+        absolute_redirect off;
+        proxy_pass http://mediamtx/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
Closes #74 and #86
* Pin nginx and mediamtx verions
* Configure nginx redirect to be relational
* Add timeout for ffmpeg so that printers can reconnect after power cycle / network event