### PR TITLE
Fix docker jar links

### DIFF
--- a/docker/bambu-liveview/README.md
+++ b/docker/bambu-liveview/README.md
@@ -28,7 +28,7 @@ To enable access from internet, add your public ip or DNS **OR** to enable acces
 
 # Bambu Web
 
-* Download the [latest](/releases/latest) version of bambu-web-X.X.X-runner.jar
+* Download the [latest](https://github.com/TFyre/bambu-farm/releases) version of bambu-web-X.X.X-runner.jar
 * `bambu-web-env.txt` is the config file instead of normal `.env`
 * Update `compose.yml` and replace `bambu-web-X.X.X-runner.jar` with the correct version
 

--- a/docker/bambu-liveview/README.md
+++ b/docker/bambu-liveview/README.md
@@ -28,7 +28,8 @@ To enable access from internet, add your public ip or DNS **OR** to enable acces
 
 # Bambu Web
 
-* Download the [latest](https://github.com/TFyre/bambu-farm/releases) version of bambu-web-X.X.X-runner.jar
+* Download the [latest](https://github.com/TFyre/bambu-farm/releases/latest) version of bambu-web-X.X.X-runner.jar
+
 * `bambu-web-env.txt` is the config file instead of normal `.env`
 * Update `compose.yml` and replace `bambu-web-X.X.X-runner.jar` with the correct version
 


### PR DESCRIPTION
The documentation links to a 404

https://github.com/TFyre/bambu-farm/blob/main/releases/latest

