### PR TITLE
Fix typo in readme

### DIFF
--- a/docker/bambu-liveview/README.md
+++ b/docker/bambu-liveview/README.md
@@ -82,7 +82,7 @@ Edit `compose.yml` and fix the printers (lines with FIXME)
 > [!NOTE]
 > `PRINTER_ID` is the printer id in the `.env` configuration file eg: 
 > ```properties
-> bambu.printer.PRINTER_ID.name=My Printer Name
+> bambu.printers.PRINTER_ID.name=My Printer Name
 > ```
 
 # Ports required for outside access


### PR DESCRIPTION
In the config options the variable appears to be `bambu.printers`, whereas the docs reference `bambu.printer`. 

this PR adds the missing `s`. 

Feel free to reject/close if this is not correct. 