### PR TITLE
Add Bambu's translucent PETG

### DIFF
--- a/bambu/src/main/java/com/tfyre/bambu/printer/Filament.java
+++ b/bambu/src/main/java/com/tfyre/bambu/printer/Filament.java
@@ -20,6 +20,7 @@ public enum Filament {
     BAMBU_PC("GFC00", "Bambu PC", FilamentType.PC),
     BAMBU_PET_CF("GFT01", "Bambu PET-CF", FilamentType.PETCF),
     BAMBU_PETG_BASIC("GFG00", "Bambu PETG Basic", FilamentType.PETG),
+    BAMBU_PETG_TRANSLUCENT("GFG01", "Bambu PETG Translucent", FilamentType.PETG),
     BAMBU_PETG_CF("GFG50", "Bambu PETG-CF", FilamentType.PETGCF),
     BAMBU_PLA_AERO("GFA11", "Bambu PLA Aero", FilamentType.PLA_AERO),
     BAMBU_PLA_BASIC("GFA00", "Bambu PLA Basic", FilamentType.PLA),


### PR DESCRIPTION
This is what the printer reports when using PETG Translucent - Clear

{
          "id": "2",
          "remain": -1,
          "k": 0.019999999552965164,
          "n": 1.0,
          "tag_uid": "03C3BEA100000100",
          "tray_id_name": "G01-C0",
          "tray_info_idx": "GFG01",
          "tray_type": "PETG",
          "tray_sub_brands": "PETG Translucent",
          "tray_color": "00000000",
          "tray_weight": "1000",
          "tray_diameter": "1.75",
	  ...
},