### PR TITLE
Allow "Done" signal for AMS free operation

### DIFF
--- a/bambu/src/main/java/com/tfyre/bambu/printer/BambuPrinter.java
+++ b/bambu/src/main/java/com/tfyre/bambu/printer/BambuPrinter.java
@@ -40,6 +40,8 @@ public interface BambuPrinter {
 
     void commandFullStatus(final boolean force);
 
+    void commandDone();
+
     void commandClearPrinterError();
 
     void commandLight(BambuConst.LightMode lightMode);

--- a/bambu/src/main/java/com/tfyre/bambu/printer/BambuPrinterImpl.java
+++ b/bambu/src/main/java/com/tfyre/bambu/printer/BambuPrinterImpl.java
@@ -369,6 +369,19 @@ public class BambuPrinterImpl implements BambuPrinter, Processor {
     }
 
     @Override
+    public void commandDone() {
+        logUser("%s: commandDone".formatted(name));
+        final BambuMessage message = BambuMessage.newBuilder()
+                .setPrint(
+                        com.tfyre.bambu.model.Print.newBuilder()
+                                .setSequenceId("%d".formatted(counter.incrementAndGet()))
+                                .setCommand("done")
+                )
+                .build();
+        toJson(message).ifPresent(this::sendData);
+    }
+
+    @Override
     public void commandFilamentUnload() {
         logUser("%s: commandFilamentUnload".formatted(name));
         final BambuMessage message = BambuMessage.newBuilder()

--- a/bambu/src/main/java/com/tfyre/bambu/view/dashboard/DashboardPrinter.java
+++ b/bambu/src/main/java/com/tfyre/bambu/view/dashboard/DashboardPrinter.java
@@ -408,6 +408,7 @@ public final class DashboardPrinter implements NotificationHelper, ViewHelper {
                     newButton("Show SD Card", VaadinIcon.ARCHIVE, l -> UI.getCurrent().navigate(SdCardView.class, printer.getName())),
                     newButton("Request full status", VaadinIcon.REFRESH, l -> printer.commandFullStatus(true)),
                     newButton("Clear Print Error", VaadinIcon.WARNING, l -> printer.commandClearPrinterError()),
+                    newButton("Send Done", VaadinIcon.ENTER, l -> printer.commandDone()),
                     newButton("Resume Print", VaadinIcon.PLAY, l -> doConfirm(BambuConst.CommandControl.RESUME)),
                     newButton("Pause Print", VaadinIcon.PAUSE, l -> doConfirm(BambuConst.CommandControl.PAUSE)),
                     newButton("Stop Print", VaadinIcon.STOP, l -> doConfirm(BambuConst.CommandControl.STOP))

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
 
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>24.8.3</vaadin.version>
+        <vaadin.version>24.8.5</vaadin.version>
         <quarkus.version>3.25.0</quarkus.version>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <jna.version>5.17.0</jna.version>


### PR DESCRIPTION
This lets me hit the "Done" command remotely.

Probably.

I tried it but it was a weird state on my printer at least, and I think hitting "Done" does something but I ended up not being able to validate that.